### PR TITLE
bugfix for crash when module closes

### DIFF
--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -68,7 +68,11 @@ To use these, replace INSTANCENAME with the name of your module instance.
 Feedback | Description
 -----------------|---------------
 **Cue Number Color as Background** | Use the Go Button color for specified cue number as background.<br />Only works for Hit cues. Use HIT# where # is the Hit number for the cue number.
-**Color when Full Screen** | Set the button color when Go Button is Full Screen
-**Color when Master Fader Visible** | Set the button color when the Master Fader is Visible
-**Color when Dimmed** | Set the button color when Master Fader is Dimmed
-**Color when Muted** | Set the button color when Master Fader is Muted
+**Color when Full Screen** | Indicate on a button when Go Button is Full Screen
+**Color when Master Fader Visible** | Indicate on a button when the Master Fader is Visible
+**Color when Dimmed** | Indicate on a button when Master Fader is Dimmed
+**Color when Muted** | Indicate on a button when Master Fader is Muted
+
+--------
+Contributions for development of this open source module are always welcome
+https://github.com/sponsors/istnv

--- a/gobutton.js
+++ b/gobutton.js
@@ -62,7 +62,7 @@ class GoButtonInstance extends InstanceBase {
 		this.needPasscode = false
 		this.useTCP = config.useTCP
 		this.hasError = false
-		this.disabled = true
+		this.disabled = false
 		this.pollCount = 0
 		this.resetVars()
 		this.init_actions()
@@ -123,8 +123,8 @@ class GoButtonInstance extends InstanceBase {
 			this.updateNextCue()
 			this.updatePlaying()
 
-			Object.keys(cues).forEach(function (cue) {
-				qNum = cleanCueNum(cues[cue].qNumber)
+			Object.keys(cues).forEach((cue) => {
+				qNum = this.cleanCueNum(cues[cue].qNumber)
 				qName = cues[cue].qName
 				if (qNum != '' && qName != '') {
 					delete this.cueColors[qNum]
@@ -292,7 +292,7 @@ class GoButtonInstance extends InstanceBase {
 			}, 5000)
 		} else if (self.needShow && self.ready) {
 			if (self.config?.passcode !== '') {
-				self.log('debug', 'sending  ' + self.config.host)
+				self.log('debug', 'sending passcode to ' + self.config.host)
 				self.sendOSC('/connect', [{ type: 's', value: self.config.passcode }])
 			} else {
 				self.sendOSC('/connect', [])
@@ -309,14 +309,14 @@ class GoButtonInstance extends InstanceBase {
 				clearTimeout(self.timer)
 				self.timer = undefined
 			}
-			self.timer = setTimeout(function () {
+			self.timer = setTimeout(() => {
 				self.prime_vars()
 			}, 5000)
 		}
 	}
 
 	/**
-	 * heartbeat/poll function for 'updates' that aren't automatic
+	 * heartbeat/poll for 'updates' that aren't automatic
 	 */
 	rePulse() {
 		const rc = this.runningCue
@@ -401,19 +401,17 @@ class GoButtonInstance extends InstanceBase {
 					self.updateStatus(InstanceStatus.ConnectionFailure, 'Cannot connect to Go Button\n' + err.message)
 					self.hasError = true
 				}
-				if (err.code == 'ECONNREFUSED') {
-					self.qSocket.removeAllListeners()
-					if (self.timer !== undefined) {
-						clearTimeout(self.timer)
-					}
-					if (self.pulse !== undefined) {
-						clearInterval(self.pulse)
-						self.pulse = undefined
-					}
-					self.timer = setTimeout(function () {
-						self.connect()
-					}, 5000)
+				self.qSocket.removeAllListeners()
+				if (self.timer !== undefined) {
+					clearTimeout(self.timer)
 				}
+				if (self.pulse !== undefined) {
+					clearInterval(self.pulse)
+					self.pulse = undefined
+				}
+				self.timer = setTimeout(() => {
+					self.connect()
+				}, 5000)
 			})
 
 			self.qSocket.on('close', () => {
@@ -479,7 +477,7 @@ class GoButtonInstance extends InstanceBase {
 				}
 			})
 		}
-		// self.qSocket.on("data", function(data){
+		// self.qSocket.on("data", (data) => {
 		// 	debug ("Got",data, "from",self.qSocket.options.address);
 		// });
 	}
@@ -745,10 +743,10 @@ class GoButtonInstance extends InstanceBase {
 			delete this.pulse
 		}
 		if (this.qSocket) {
-			this.disabled = true
 			this.qSocket.close()
 			delete this.qSocket
 		}
+		this.disabled = true
 		this.updateStatus(InstanceStatus.UnknownError, 'Disabled')
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "figure53-go-button",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"main": "gobutton.js",
 	"type": "module",
 	"manufacturer": "Figure 53",


### PR DESCRIPTION
Module would crash when clearing internal variables when `go-button` closed or module disabled